### PR TITLE
Add rate limiting, DDoS protection, and security headers

### DIFF
--- a/lib/actions/book.actions.ts
+++ b/lib/actions/book.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { checkCreateLimit } from '@/lib/premium';
@@ -602,6 +603,8 @@ export async function addCommentAction(
   parentId?: string | null,
 ): Promise<ActionResult> {
   const userId = await requireAuth();
+  const limited = await checkActionRateLimit(userId);
+  if (limited) return { success: false, message: limited };
 
   const chapter = await db.query.chapters.findFirst({
     where: eq(chapters.id, chapterId),

--- a/lib/actions/cloudinary.actions.ts
+++ b/lib/actions/cloudinary.actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
-
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 import { cloudinary } from '@/lib/cloudinary';
 
 type UploadFolder = 'covers' | 'avatars';
@@ -9,6 +9,8 @@ type UploadFolder = 'covers' | 'avatars';
 export async function generateUploadSignatureAction(folder: UploadFolder, entityId: string) {
   const userId = await requireAuth();
   if (!userId) throw new Error('Unauthorized');
+  const limited = await checkActionRateLimit(userId);
+  if (limited) throw new Error(limited);
 
   const cloudFolder = folder === 'covers' ? 'hive-covers' : 'hive-avatars';
   const timestamp   = Math.round(Date.now() / 1000);

--- a/lib/actions/club.actions.ts
+++ b/lib/actions/club.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { checkCreateLimit } from '@/lib/premium';
@@ -423,6 +424,8 @@ export async function createClubDiscussionAction(
   data: ClubDiscussionFormData,
 ): Promise<ActionResult & { discussionId?: string }> {
   const { userId } = await requireClubMember(clubId);
+  const limited = await checkActionRateLimit(userId);
+  if (limited) return { success: false, message: limited };
   const parsed = clubDiscussionSchema.safeParse(data);
   if (!parsed.success) return { success: false, message: parsed.error.issues[0].message };
 
@@ -661,6 +664,8 @@ export async function createDiscussionReplyAction(
   parentId?: string,
 ): Promise<ActionResult & { replyId?: string }> {
   const { userId } = await requireClubMember(clubId);
+  const limited = await checkActionRateLimit(userId);
+  if (limited) return { success: false, message: limited };
   const parsed = clubReplySchema.safeParse({ content });
   if (!parsed.success) return { success: false, message: parsed.error.issues[0].message };
 

--- a/lib/actions/hive-buzz.actions.ts
+++ b/lib/actions/hive-buzz.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, desc, eq, ne, sql } from 'drizzle-orm';
@@ -55,6 +56,8 @@ export async function createBuzzItemAction(
 ): Promise<ActionResult & { itemId?: string }> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     const trimmed = content.trim();
     if (!trimmed) return { success: false, message: 'Content is required.' };

--- a/lib/actions/hive-chat.actions.ts
+++ b/lib/actions/hive-chat.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, asc, desc, eq } from 'drizzle-orm';
@@ -80,6 +81,8 @@ export async function sendChatMessageAction(
 ): Promise<ActionResult> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
     const trimmed = content.trim();
     if (!trimmed) return { success: false, message: 'Message cannot be empty.' };
     if (trimmed.length > 2000) return { success: false, message: 'Message too long (max 2000 chars).' };

--- a/lib/actions/hive-inline-comments.actions.ts
+++ b/lib/actions/hive-inline-comments.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, asc, desc, eq, ne } from 'drizzle-orm';
@@ -96,6 +97,8 @@ export async function createInlineCommentAction(
 ): Promise<ActionResult & { commentId?: string }> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     if (!content.trim()) return { success: false, message: 'Comment text is required.' };
     if (content.length > 2000) return { success: false, message: 'Comment too long (max 2000 chars).' };

--- a/lib/actions/hive-polls.actions.ts
+++ b/lib/actions/hive-polls.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, desc, eq } from 'drizzle-orm';
@@ -103,6 +104,8 @@ export async function createPollAction(
 ): Promise<ActionResult & { pollId?: string }> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     if (!question.trim()) return { success: false, message: 'Question is required.' };
     const cleanOptions = options.map((o) => o.trim()).filter(Boolean);
@@ -160,6 +163,8 @@ export async function voteOnPollAction(
 ): Promise<ActionResult> {
   try {
     const userId = await requireAuth();
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     const poll = await db.query.hivePolls.findFirst({
       where: eq(hivePolls.id, pollId),

--- a/lib/actions/hive-sprints.actions.ts
+++ b/lib/actions/hive-sprints.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, desc, eq } from 'drizzle-orm';
@@ -191,6 +192,8 @@ export async function submitWordsAction(
 ): Promise<ActionResult> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     const participant = await db.query.hiveSprintParticipants.findFirst({
       where: and(

--- a/lib/actions/hive-wiki.actions.ts
+++ b/lib/actions/hive-wiki.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { revalidatePath } from 'next/cache';
 import { and, asc, desc, eq, ne } from 'drizzle-orm';
@@ -88,6 +89,8 @@ export async function createWikiEntryAction(
 ): Promise<ActionResult & { entryId?: string }> {
   try {
     const { userId } = await requireHiveMember(hiveId);
+    const limited = await checkActionRateLimit(userId);
+    if (limited) return { success: false, message: limited };
 
     if (!title.trim()) return { success: false, message: 'Title is required.' };
     if (title.length > 200) return { success: false, message: 'Title too long (max 200 chars).' };

--- a/lib/actions/prompt.actions.ts
+++ b/lib/actions/prompt.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { checkActionRateLimit } from '@/lib/check-action-rate-limit';
 
 import { and, eq, or, sql } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
@@ -601,6 +602,8 @@ export async function createEntryAction(
   content: string,
 ): Promise<ActionResult & { entryId?: string }> {
   const userId = await requireAuth();
+  const limited = await checkActionRateLimit(userId);
+  if (limited) return { success: false, message: limited };
 
   const prompt = await db.query.prompts.findFirst({
     where: eq(prompts.id, promptId),
@@ -738,6 +741,8 @@ export async function addEntryCommentAction(
   parentId?: string | null,
 ): Promise<ActionResult> {
   const userId = await requireAuth();
+  const limited = await checkActionRateLimit(userId);
+  if (limited) return { success: false, message: limited };
 
   const parsed = entryCommentSchema.safeParse({ content });
   if (!parsed.success)

--- a/lib/check-action-rate-limit.ts
+++ b/lib/check-action-rate-limit.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { actionLimiter } from '@/lib/rate-limit';
+
+/**
+ * Call at the top of any server action that can be spammed.
+ * Uses the userId as the rate limit key so limits are per-user, not per-IP.
+ *
+ * Returns an error string if rate limited, null if OK.
+ *
+ * Usage:
+ *   const limited = await checkActionRateLimit(userId);
+ *   if (limited) return { error: limited };
+ */
+export async function checkActionRateLimit(userId: string): Promise<string | null> {
+  const { success } = await actionLimiter.limit(userId);
+  if (!success) return 'You are doing that too fast. Please wait a moment.';
+  return null;
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,53 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+// 5 sign-up attempts per hour per IP
+export const signUpLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, '1 h'),
+  prefix: 'rl:signup',
+});
+
+// 10 sign-in attempts per 15 minutes per IP (brute-force protection)
+export const signInLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(10, '15 m'),
+  prefix: 'rl:signin',
+});
+
+// 5 checkout attempts per hour per IP (prevent subscription spam)
+export const checkoutLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, '1 h'),
+  prefix: 'rl:checkout',
+});
+
+// 60 requests per minute per IP for all other API routes
+export const apiLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(60, '1 m'),
+  prefix: 'rl:api',
+});
+
+// For use inside server actions (comments, uploads, etc.)
+// 20 mutations per minute per user
+export const actionLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(20, '1 m'),
+  prefix: 'rl:action',
+});
+
+// 200 page requests per minute per IP (DDoS protection for page routes)
+export const pageLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(200, '1 m'),
+  prefix: 'rl:page',
+
+  // Ephemeral cache reduces Redis calls for legitimate users
+  ephemeralCache: new Map(),
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { signUpLimiter, signInLimiter, checkoutLimiter, apiLimiter, pageLimiter } from '@/lib/rate-limit';
 
 const PUBLIC_PATHS = ['/', '/sign-in', '/sign-up'];
+
+// Known malicious/scanner user-agent fragments
+const BLOCKED_UA_PATTERNS = [
+  'sqlmap', 'nikto', 'nmap', 'masscan', 'zgrab',
+  'dirbuster', 'gobuster', 'wfuzz', 'nuclei', 'acunetix',
+  'nessus', 'openvas', 'w3af', 'skipfish',
+];
 
 function isPublic(pathname: string) {
   return PUBLIC_PATHS.some((p) =>
@@ -8,14 +16,76 @@ function isPublic(pathname: string) {
   );
 }
 
-export default function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+function getIp(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'anonymous'
+  );
+}
 
-  // Let auth and payment API routes pass through
-  if (pathname.startsWith('/api/auth') || pathname.startsWith('/api/stripe')) {
+function rateLimitedResponse(retryAfter = 60) {
+  return NextResponse.json(
+    { error: 'Too many requests. Please slow down.' },
+    { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+  );
+}
+
+function isSuspiciousBot(request: NextRequest): boolean {
+  const ua = request.headers.get('user-agent')?.toLowerCase() ?? '';
+  return BLOCKED_UA_PATTERNS.some((pattern) => ua.includes(pattern));
+}
+
+export default async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const ip = getIp(request);
+
+  // ── Block known scanner / attack tools ────────────────────────────────────
+  if (isSuspiciousBot(request)) {
+    return new NextResponse(null, { status: 403 });
+  }
+
+  // ── Rate limit auth endpoints ──────────────────────────────────────────────
+  if (pathname.startsWith('/api/auth')) {
+    let result;
+    if (pathname.includes('/sign-up')) {
+      result = await signUpLimiter.limit(ip);
+    } else if (pathname.includes('/sign-in')) {
+      result = await signInLimiter.limit(ip);
+    } else {
+      result = await apiLimiter.limit(ip);
+    }
+    if (!result.success) return rateLimitedResponse();
     return NextResponse.next();
   }
 
+  // ── Rate limit Stripe endpoints ────────────────────────────────────────────
+  if (pathname.startsWith('/api/stripe')) {
+    // Webhooks come from Stripe servers — never rate limit them
+    if (!pathname.includes('/webhook')) {
+      const result = await checkoutLimiter.limit(ip);
+      if (!result.success) return rateLimitedResponse(3600);
+    }
+    return NextResponse.next();
+  }
+
+  // ── Rate limit all other API routes ───────────────────────────────────────
+  if (pathname.startsWith('/api/')) {
+    const result = await apiLimiter.limit(ip);
+    if (!result.success) return rateLimitedResponse();
+    return NextResponse.next();
+  }
+
+  // ── Rate limit page routes (DDoS protection) ──────────────────────────────
+  const pageResult = await pageLimiter.limit(ip);
+  if (!pageResult.success) {
+    return new NextResponse('Too many requests', {
+      status: 429,
+      headers: { 'Retry-After': '60', 'Content-Type': 'text/plain' },
+    });
+  }
+
+  // ── Page route auth guard ─────────────────────────────────────────────────
   const sessionToken =
     request.cookies.get('better-auth.session_token') ??
     request.cookies.get('__Secure-better-auth.session_token');
@@ -29,9 +99,6 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Authenticated user visiting root → send to /home
-  // /sign-in and /sign-up are handled by the auth layout with proper session
-  // validation, to avoid redirect loops when the session cookie is stale.
   if (pathname === '/') {
     return NextResponse.redirect(new URL('/home', request.url));
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,21 +1,38 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+
+const securityHeaders = [
+  // Prevent clickjacking — page cannot be embedded in iframes
+  { key: 'X-Frame-Options', value: 'DENY' },
+  // Prevent MIME-type sniffing
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  // Only send referrer on same-origin requests
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  // Disable browser features the app doesn't use
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), payment=()' },
+  // Force HTTPS for 1 year in production (subdomains included)
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+  // Enable XSS filter in older browsers
+  { key: 'X-XSS-Protection', value: '1; mode=block' },
+  // Disable DNS prefetch to prevent DNS leakage
+  { key: 'X-DNS-Prefetch-Control', value: 'off' },
+];
 
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'img.clerk.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'lh3.googleusercontent.com',
-      },
+      { protocol: 'https', hostname: 'res.cloudinary.com' },
+      { protocol: 'https', hostname: 'lh3.googleusercontent.com' },
     ],
+  },
+
+  async headers() {
+    return [
+      {
+        // Apply to all routes
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@tiptap/pm": "^3.20.0",
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "better-auth": "^1.5.5",
         "class-variance-authority": "^0.7.1",
         "cloudinary": "^2.9.0",
@@ -6382,6 +6384,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
@@ -15337,6 +15373,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/underscore": {
       "version": "1.13.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "better-auth": "^1.5.5",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "^2.9.0",


### PR DESCRIPTION
## Summary
- Integrates Upstash Redis rate limiting in middleware for auth (sign-up/sign-in), Stripe, and all API routes
- Adds page-level rate limiting (200 req/min/IP) with ephemeral cache to prevent DoS on server-rendered routes
- Blocks known vulnerability scanner user agents (sqlmap, nikto, nmap, nuclei, acunetix, etc.) at the edge
- Rate limits all spammable server actions per user: comments, prompt entries, club discussions/replies, hive chat, buzz, polls, wiki, sprints, and Cloudinary uploads
- Adds HTTP security headers to all responses: X-Frame-Options, X-Content-Type-Options, HSTS, Referrer-Policy, Permissions-Policy, X-XSS-Protection
- Removes leftover img.clerk.com from the image allowlist

## Test plan
- [x] Sign up with a new account works normally (not rate limited)
- [x] Hitting sign-up more than 5 times in an hour returns 429
- [x] Hitting sign-in more than 10 times in 15 minutes returns 429
- [x] Page navigation feels unaffected for normal use
- [x] Security headers present in response (check DevTools → Network → any request → Response Headers)
- [x] Posting comments works; rapid-firing 20+ in a minute returns an error message