### PR TITLE
Added user feedback collection system

### DIFF
--- a/app/[locale]/(app)/admin/feedback/page.tsx
+++ b/app/[locale]/(app)/admin/feedback/page.tsx
@@ -1,0 +1,18 @@
+import { getFeedbackAdminAction } from '@/lib/actions/feedback.actions';
+import FeedbackTable from '@/components/admin/feedback-table';
+
+export default async function AdminFeedbackPage() {
+  const items = await getFeedbackAdminAction();
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white">Feedback</h1>
+        <p className="text-sm text-white/60 mt-1">
+          User-submitted feedback, suggestions, and support requests.
+        </p>
+      </div>
+      <FeedbackTable items={items} />
+    </div>
+  );
+}

--- a/app/[locale]/(app)/feedback/page.tsx
+++ b/app/[locale]/(app)/feedback/page.tsx
@@ -1,0 +1,22 @@
+import FeedbackForm from '@/components/feedback/feedback-form';
+
+
+export default function FeedbackPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-10">
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+       
+          <h1 className="text-2xl font-bold text-white">Send Feedback</h1>
+        </div>
+        <p className="text-sm text-white/80 mt-1">
+          Have a suggestion, found a bug, or just want to say something? We would love to hear from you.
+        </p>
+      </div>
+
+      <div className="rounded-2xl bg-[#252525] border border-[#2a2a2a] p-6">
+        <FeedbackForm />
+      </div>
+    </div>
+  );
+}

--- a/components/admin/admin-mobile-nav.tsx
+++ b/components/admin/admin-mobile-nav.tsx
@@ -11,6 +11,7 @@ import {
   Bell,
   Layers,
   Megaphone,
+  MessageSquarePlus,
 } from 'lucide-react';
 
 const links = [
@@ -22,6 +23,7 @@ const links = [
   { href: '/admin/discussions', label: 'Discussions', icon: MessageSquare },
   { href: '/admin/prompts', label: 'Prompts', icon: Lightbulb },
   { href: '/admin/announcements', label: 'Announcements', icon: Megaphone },
+  { href: '/admin/feedback', label: 'Feedback', icon: MessageSquarePlus },
   { href: '/admin/notifications', label: 'Notifications', icon: Bell },
 ];
 

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Layers,
   ChevronLeft,
   Megaphone,
+  MessageSquarePlus,
 } from 'lucide-react';
 
 const links = [
@@ -24,6 +25,7 @@ const links = [
   { href: '/admin/discussions', label: 'Discussions', icon: MessageSquare },
   { href: '/admin/prompts', label: 'Prompts', icon: Lightbulb },
   { href: '/admin/announcements', label: 'Announcements', icon: Megaphone },
+  { href: '/admin/feedback', label: 'Feedback', icon: MessageSquarePlus },
   // { href: '/admin/notifications', label: 'Notifications', icon: Bell },
 ];
 

--- a/components/admin/feedback-table.tsx
+++ b/components/admin/feedback-table.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trash2, MessageSquarePlus, Mail, Tag } from 'lucide-react';
+import ConfirmDeleteDialog from '@/components/admin/confirm-delete-dialog';
+import { deleteFeedbackAdminAction } from '@/lib/actions/feedback.actions';
+import type { FeedbackItem } from '@/lib/actions/feedback.actions';
+
+const typeLabels: Record<FeedbackItem['type'], string> = {
+  content_suggestion: 'Content Suggestion',
+  general_feedback: 'General Feedback',
+  technical_support: 'Technical Support',
+};
+
+const typeBadgeClass: Record<FeedbackItem['type'], string> = {
+  content_suggestion: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  general_feedback: 'bg-[#FFC300]/10 text-[#FFC300] border-[#FFC300]/20',
+  technical_support: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+interface Props {
+  items: FeedbackItem[];
+}
+
+export default function FeedbackTable({ items }: Props) {
+  const router = useRouter();
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [isDeleting, startDeleting] = useTransition();
+
+  function handleDelete(id: string) {
+    startDeleting(async () => {
+      await deleteFeedbackAdminAction(id);
+      setDeleteId(null);
+      router.refresh();
+    });
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-[#2a2a2a] py-16 text-center">
+        <MessageSquarePlus className="w-8 h-8 text-white/20 mx-auto mb-3" />
+        <p className="text-sm text-white/40">No feedback submissions yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-2xl bg-[#252525] border border-[#2a2a2a] divide-y divide-[#2a2a2a] overflow-hidden">
+        {items.map((item) => (
+          <div key={item.id} className="px-5 py-4 flex items-start gap-4">
+            <div className="flex-1 min-w-0 space-y-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border ${typeBadgeClass[item.type]}`}
+                >
+                  <Tag className="w-3 h-3" />
+                  {typeLabels[item.type]}
+                </span>
+                {item.email && (
+                  <span className="inline-flex items-center gap-1 text-[11px] text-white/50">
+                    <Mail className="w-3 h-3" />
+                    {item.email}
+                  </span>
+                )}
+                <span className="text-[11px] text-white/30 ml-auto shrink-0">
+                  {new Date(item.createdAt).toLocaleDateString([], {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+              <p className="text-sm text-white/80 leading-relaxed whitespace-pre-wrap break-words">
+                {item.content}
+              </p>
+            </div>
+            <button
+              onClick={() => setDeleteId(item.id)}
+              className="shrink-0 text-white/30 hover:text-red-400 transition-colors mt-0.5"
+              aria-label="Delete feedback"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDeleteDialog
+        open={deleteId !== null}
+        onClose={() => setDeleteId(null)}
+        onConfirm={() => deleteId && handleDelete(deleteId)}
+        title="Delete Feedback"
+        description="This will permanently remove this feedback submission."
+        loading={isDeleting}
+      />
+    </>
+  );
+}

--- a/components/feedback/feedback-form.tsx
+++ b/components/feedback/feedback-form.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useRouter } from 'next/navigation';
+import { MessageSquarePlus, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { submitFeedbackAction } from '@/lib/actions/feedback.actions';
+
+const schema = z.object({
+  type: z.enum(['content_suggestion', 'general_feedback', 'technical_support']),
+  email: z.string().email('Invalid email address').or(z.literal('')),
+  content: z.string().min(10, 'Feedback must be at least 10 characters').max(2000),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const feedbackTypes = [
+  { value: 'content_suggestion', label: 'Content Suggestion' },
+  { value: 'general_feedback', label: 'General Feedback' },
+  { value: 'technical_support', label: 'Technical Support' },
+] as const;
+
+export default function FeedbackForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [submitted, setSubmitted] = useState(false);
+  const [serverError, setServerError] = useState('');
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      type: 'general_feedback',
+      email: '',
+      content: '',
+    },
+  });
+
+  function onSubmit(values: FormValues) {
+    setServerError('');
+    startTransition(async () => {
+      const result = await submitFeedbackAction(values);
+      if (result.success) {
+        setSubmitted(true);
+      } else {
+        setServerError(result.message);
+      }
+    });
+  }
+
+  if (submitted) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+        <CheckCircle2 className="w-12 h-12 text-[#FFC300]" />
+        <h2 className="text-xl font-bold text-white">Thank you!</h2>
+        <p className="text-white/80 text-sm max-w-xs">
+          Your feedback has been submitted. We appreciate you taking the time to share it with us.
+        </p>
+        <Button
+          onClick={() => router.back()}
+          className="mt-2 bg-[#FFC300] text-black hover:bg-[#FFD040] font-semibold"
+        >
+          Go back
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div>
+        <label className="block text-xs font-semibold text-white/80 uppercase tracking-wide mb-2">
+          Feedback Type
+        </label>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          {feedbackTypes.map(({ value, label }) => (
+            <label
+              key={value}
+              className="relative flex items-center gap-2 px-4 py-3 rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] cursor-pointer hover:border-[#FFC300]/30 transition-all has-checked:border-[#FFC300]/60 has-checked:bg-[#FFC300]/5"
+            >
+              <input
+                {...register('type')}
+                type="radio"
+                value={value}
+                className="sr-only"
+              />
+              <span className="text-sm font-medium text-white/80">{label}</span>
+            </label>
+          ))}
+        </div>
+        {errors.type && (
+          <p className="mt-1 text-xs text-red-400">{errors.type.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-xs font-semibold text-white/80 uppercase tracking-wide mb-2">
+          Email <span className="normal-case font-normal text-white/70">(optional — for a response)</span>
+        </label>
+        <input
+          {...register('email')}
+          type="email"
+          placeholder="you@example.com"
+          className="w-full bg-[#1a1a1a] border border-[#2a2a2a] rounded-xl px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-[#FFC300]/40 transition-colors"
+        />
+        {errors.email && (
+          <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-xs font-semibold text-white/70 uppercase tracking-wide mb-2">
+          Your Feedback
+        </label>
+        <textarea
+          {...register('content')}
+          rows={6}
+          placeholder="Share your thoughts, suggestions, or describe your issue…"
+          className="w-full bg-[#1a1a1a] border border-[#2a2a2a] rounded-xl px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-[#FFC300]/40 transition-colors resize-none"
+        />
+        {errors.content && (
+          <p className="mt-1 text-xs text-red-400">{errors.content.message}</p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="text-sm text-red-400">{serverError}</p>
+      )}
+
+      <Button
+        type="submit"
+        disabled={isPending}
+        className="w-full bg-[#FFC300] text-black hover:bg-[#FFD040] font-semibold flex items-center justify-center gap-2"
+      >
+        <MessageSquarePlus className="w-4 h-4" />
+        {isPending ? 'Submitting…' : 'Submit Feedback'}
+      </Button>
+    </form>
+  );
+}

--- a/components/nav/desktop-sidebar.tsx
+++ b/components/nav/desktop-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   LogOut,
   Hexagon,
   ShieldCheck,
+  MessageSquarePlus,
 } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications/notification-bell';
 import { UserSkeleton } from '@/components/ui/skeleton';
@@ -139,6 +140,26 @@ export function DesktopSidebar({ isAdmin = false }: { isAdmin?: boolean }) {
             )}
           </ul>
         </nav>
+
+        <div className="px-2 xl:px-3 pb-2 pt-1">
+          <Link
+            href="/feedback"
+            aria-label="Send Feedback"
+            aria-current={isActive('/feedback') ? 'page' : undefined}
+            className={`flex items-center md:justify-center lg:justify-start gap-4 md:p-3 lg:px-4 lg:py-3 rounded-2xl text-[15px] font-semibold transition-all duration-150 ${
+              isActive('/feedback')
+                ? 'text-[#FFC300]'
+                : 'text-white/90 hover:text-white hover:bg-white/5'
+            }`}
+          >
+            <MessageSquarePlus
+              aria-hidden="true"
+              className="w-5.5 h-5.5 shrink-0"
+              strokeWidth={isActive('/feedback') ? 2.5 : 1.75}
+            />
+            <span className="hidden lg:block" aria-hidden="true">Feedback</span>
+          </Link>
+        </div>
 
         <div className="px-2 xl:px-3 pb-4 pt-3 border-t border-[#2a2a2a]">
           {isPending ? (

--- a/components/nav/mobile-navbar.tsx
+++ b/components/nav/mobile-navbar.tsx
@@ -21,6 +21,7 @@ import {
   LogOut,
   Hexagon,
   ShieldCheck,
+  MessageSquarePlus,
 } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications/notification-bell';
 import logoImage from '@/public/logo3.png';
@@ -230,6 +231,24 @@ export function MobileNavbar({ isAdmin = false }: { isAdmin?: boolean }) {
             )}
           </div>
         </nav>
+
+        <div className="px-3 pb-3 pt-3 border-t border-[#2a2a2a]">
+          <Link
+            href="/feedback"
+            onClick={closeDrawer}
+            className={`flex items-center gap-3 px-4 py-3 rounded-2xl text-sm font-semibold transition-all ${
+              isActive('/feedback')
+                ? 'text-[#FFC300] bg-[#FFC300]/8'
+                : 'text-white/80 hover:text-white hover:bg-white/5'
+            }`}
+          >
+            <MessageSquarePlus
+              className="w-5 h-5 shrink-0"
+              strokeWidth={isActive('/feedback') ? 2.5 : 1.75}
+            />
+            Send Feedback
+          </Link>
+        </div>
 
         <div className="px-3 pb-8 pt-3 border-t border-[#2a2a2a]">
           <div className="flex gap-2">

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -296,6 +296,22 @@ export const announcements = pgTable('announcements', {
 });
 
 // ---------------------------------------------------------------------------
+// Feedback
+// ---------------------------------------------------------------------------
+
+export const feedback = pgTable('feedback', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  type: text('type', {
+    enum: ['content_suggestion', 'general_feedback', 'technical_support'],
+  }).notNull(),
+  email: text('email'),
+  content: text('content').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+// ---------------------------------------------------------------------------
 // Relations
 // ---------------------------------------------------------------------------
 

--- a/lib/actions/feedback.actions.ts
+++ b/lib/actions/feedback.actions.ts
@@ -1,0 +1,75 @@
+'use server';
+
+import { db } from '@/db';
+import { feedback, users } from '@/db/schema';
+import { requireAuth } from '@/lib/require-auth';
+import { desc, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+
+export type ActionResult = { success: boolean; message: string };
+
+const feedbackSchema = z.object({
+  type: z.enum(['content_suggestion', 'general_feedback', 'technical_support']),
+  email: z.string().email().optional().or(z.literal('')),
+  content: z.string().min(10, 'Feedback must be at least 10 characters').max(2000),
+});
+
+export type FeedbackItem = {
+  id: string;
+  type: 'content_suggestion' | 'general_feedback' | 'technical_support';
+  email: string | null;
+  content: string;
+  createdAt: Date;
+};
+
+async function requireAdmin() {
+  const userId = await requireAuth();
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { role: true },
+  });
+  if (user?.role !== 'admin') throw new Error('Forbidden');
+  return userId;
+}
+
+export async function submitFeedbackAction(data: {
+  type: string;
+  email: string;
+  content: string;
+}): Promise<ActionResult> {
+  const parsed = feedbackSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.issues[0].message };
+  }
+
+  const { type, email, content } = parsed.data;
+
+  await db.insert(feedback).values({
+    type,
+    email: email || null,
+    content,
+  });
+
+  return { success: true, message: 'Thank you for your feedback!' };
+}
+
+export async function getFeedbackAdminAction(): Promise<FeedbackItem[]> {
+  await requireAdmin();
+
+  const rows = await db
+    .select()
+    .from(feedback)
+    .orderBy(desc(feedback.createdAt));
+
+  return rows as FeedbackItem[];
+}
+
+export async function deleteFeedbackAdminAction(id: string): Promise<ActionResult> {
+  await requireAdmin();
+
+  await db.delete(feedback).where(eq(feedback.id, id));
+  revalidatePath('/admin/feedback');
+
+  return { success: true, message: 'Feedback deleted.' };
+}


### PR DESCRIPTION
Add User Feedback Collection System
Implements an end-to-end feedback flow for users to submit feedback and for admins to manage submissions.

What's new
User-facing

New /feedback page with a form — feedback type selection (Content Suggestion, General Feedback, Technical Support), optional email field, and a content textarea
Feedback button added to the bottom of the desktop sidebar
Feedback link added to the bottom of the mobile drawer (above Settings / Sign Out)
Database

New feedback table (id, type, email, content, createdAt) — no relations, purely additive
Admin panel

New /admin/feedback page — lists all submissions with type badges, optional email, and date
Delete individual submissions via the existing confirm-delete dialog
Entry added to both the admin sidebar and admin mobile nav select