### PR TITLE
Add rate limiting to explore search actions

### DIFF
--- a/lib/actions/explore.actions.ts
+++ b/lib/actions/explore.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
+import { searchLimiter } from '@/lib/rate-limit';
 
 import { unstable_cache } from 'next/cache';
 import { and, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
@@ -68,6 +69,10 @@ export async function searchExplorableBooksAction(
   genres: string[] = [],
   categories: string[] = [],
 ): Promise<Book[]> {
+  const userId = await getOptionalUserId();
+  const { success } = await searchLimiter.limit(userId ?? 'anon');
+  if (!success) throw new Error('Too many requests. Please slow down.');
+
   const q = query.trim();
   const rows = await db.query.books.findMany({
     where: and(
@@ -90,6 +95,9 @@ export async function searchExplorableClubsAction(
   tags: string[] = [],
 ): Promise<ClubWithMembership[]> {
   const userId = await requireAuth();
+  const { success } = await searchLimiter.limit(userId ?? 'anon');
+  if (!success) throw new Error('Too many requests. Please slow down.');
+
   const q = query.trim();
 
   const tagFilter =
@@ -163,6 +171,9 @@ export async function searchExplorableHivesAction(
   tags: string[] = [],
 ): Promise<HiveWithMembership[]> {
   const userId = await requireAuth();
+  const { success } = await searchLimiter.limit(userId ?? 'anon');
+  if (!success) throw new Error('Too many requests. Please slow down.');
+
   const q = query.trim();
 
   const tagFilter =
@@ -232,6 +243,9 @@ export async function searchExplorableHivesAction(
 
 export async function searchExplorablePromptsAction(query: string): Promise<PromptCard[]> {
   const userId = await requireAuth();
+  const { success } = await searchLimiter.limit(userId ?? 'anon');
+  if (!success) throw new Error('Too many requests. Please slow down.');
+
   const q = query.trim();
 
   const rows = await db.query.prompts.findMany({
@@ -278,6 +292,10 @@ export async function searchExplorablePromptsAction(query: string): Promise<Prom
 
 
 export async function searchExplorableReadingListsAction(query: string): Promise<ReadingList[]> {
+  const userId = await getOptionalUserId();
+  const { success } = await searchLimiter.limit(userId ?? 'anon');
+  if (!success) throw new Error('Too many requests. Please slow down.');
+
   const q = query.trim();
   const rows = await db.query.readingLists.findMany({
     where: and(

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -42,6 +42,14 @@ export const actionLimiter = new Ratelimit({
   prefix: 'rl:action',
 });
 
+// 60 search requests per minute per user (read-only, higher limit than mutations)
+export const searchLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(60, '1 m'),
+  prefix: 'rl:search',
+  ephemeralCache: new Map(),
+});
+
 // 200 page requests per minute per IP (DDoS protection for page routes)
 export const pageLimiter = new Ratelimit({
   redis,


### PR DESCRIPTION
Adds a dedicated searchLimiter (60 requests/min, sliding window) to lib/rate-limit.ts.

Applied to all five explore search actions in lib/actions/explore.actions.ts:
- searchExplorableBooksAction
- searchExplorableClubsAction
- searchExplorableHivesAction
- searchExplorablePromptsAction
- searchExplorableReadingListsAction

Unauthenticated users fall back to a shared 'anon' key. Throws on rate limit exceeded.