### PR TITLE
Add robots.txt and sitemap for SEO

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/settings', '/onboarding', '/home'],
+      },
+    ],
+    sitemap: 'https://www.beehive-books.app/sitemap.xml',
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,48 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://www.beehive-books.app',
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: 'https://www.beehive-books.app/explore',
+      lastModified: new Date(),
+      changeFrequency: 'hourly',
+      priority: 0.9,
+    },
+    {
+      url: 'https://www.beehive-books.app/explore/books',
+      lastModified: new Date(),
+      changeFrequency: 'hourly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://www.beehive-books.app/explore/clubs',
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+    {
+      url: 'https://www.beehive-books.app/explore/hives',
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+    {
+      url: 'https://www.beehive-books.app/sign-in',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.beehive-books.app/sign-up',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+  ];
+}


### PR DESCRIPTION
Adds SEO basics using the Next.js Metadata API.

- app/robots.ts — disallows crawling of /api/, /settings, /onboarding, /home; points to sitemap
- app/sitemap.ts — static sitemap covering public routes (landing, explore, sign-in, sign-up)

Both served automatically by Next.js at /robots.txt and /sitemap.xml.