### PR TITLE
Add cursor-based pagination to explore search pages

### DIFF
--- a/app/[locale]/(app)/explore/books/page.tsx
+++ b/app/[locale]/(app)/explore/books/page.tsx
@@ -3,6 +3,7 @@ import { BookOpen } from 'lucide-react';
 import { searchExplorableBooksAction } from '@/lib/actions/explore.actions';
 import { ExploreSearchBar } from '@/components/explore/explore-search-bar';
 import { ExploreSidebar } from '@/components/explore/explore-sidebar';
+import { ExploreLoadMoreButton } from '@/components/explore/explore-load-more';
 import BookCard from '@/components/library/book-card';
 import { GENRES, CATEGORIES } from '@/lib/config/constants';
 
@@ -11,13 +12,13 @@ export const metadata: Metadata = { title: 'Explore Books' };
 export default async function ExploreBooksPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; genre?: string; category?: string }>;
+  searchParams: Promise<{ q?: string; genre?: string; category?: string; cursor?: string }>;
 }) {
-  const { q = '', genre = '', category = '' } = await searchParams;
+  const { q = '', genre = '', category = '', cursor } = await searchParams;
   const genres = genre ? genre.split(',').filter(Boolean) : [];
   const categories = category ? category.split(',').filter(Boolean) : [];
 
-  const books = await searchExplorableBooksAction(q, genres, categories);
+  const { books, nextCursor } = await searchExplorableBooksAction(q, genres, categories, cursor);
 
   const filterGroups = [
     { param: 'genre', label: 'Genre', options: GENRES },
@@ -34,7 +35,6 @@ export default async function ExploreBooksPage({
           <BookOpen className="w-6 h-6 text-[#FFC300]" />
           Books
         </h1>
-  
       </div>
 
       <ExploreSearchBar placeholder="Search by title or author..." />
@@ -54,11 +54,14 @@ export default async function ExploreBooksPage({
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-2  xl:grid-cols-3 gap-4">
-              {books.map((book) => (
-                <BookCard key={book.id} book={book} basePath="/books" />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-2 xl:grid-cols-3 gap-4">
+                {books.map((book) => (
+                  <BookCard key={book.id} book={book} basePath="/books" />
+                ))}
+              </div>
+              {nextCursor && <ExploreLoadMoreButton nextCursor={nextCursor} />}
+            </>
           )}
         </div>
       </div>

--- a/app/[locale]/(app)/explore/clubs/page.tsx
+++ b/app/[locale]/(app)/explore/clubs/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Users } from 'lucide-react';
 import { searchExplorableClubsAction } from '@/lib/actions/explore.actions';
 import { ExploreSearchBar } from '@/components/explore/explore-search-bar';
+import { ExploreLoadMoreButton } from '@/components/explore/explore-load-more';
 import ClubCard from '@/components/clubs/club-card';
 
 export const metadata: Metadata = { title: 'Explore Clubs' };
@@ -9,12 +10,12 @@ export const metadata: Metadata = { title: 'Explore Clubs' };
 export default async function ExploreClubsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; tag?: string }>;
+  searchParams: Promise<{ q?: string; tag?: string; cursor?: string }>;
 }) {
-  const { q = '', tag = '' } = await searchParams;
+  const { q = '', tag = '', cursor } = await searchParams;
   const tags = tag ? tag.split(',').filter(Boolean) : [];
 
-  const clubs = await searchExplorableClubsAction(q, tags);
+  const { clubs, nextCursor } = await searchExplorableClubsAction(q, tags, cursor);
 
   return (
     <div className="space-y-6">
@@ -26,7 +27,6 @@ export default async function ExploreClubsPage({
           <Users className="w-6 h-6 text-orange-400" />
           Book Clubs
         </h1>
-
       </div>
 
       <ExploreSearchBar placeholder="Search clubs by name, description, or tag..." />
@@ -40,11 +40,14 @@ export default async function ExploreClubsPage({
           <p className="text-white/80 max-w-sm">Try different keywords.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-          {clubs.map((club) => (
-            <ClubCard key={club.id} club={club} />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+            {clubs.map((club) => (
+              <ClubCard key={club.id} club={club} />
+            ))}
+          </div>
+          {nextCursor && <ExploreLoadMoreButton nextCursor={nextCursor} />}
+        </>
       )}
     </div>
   );

--- a/app/[locale]/(app)/explore/hives/page.tsx
+++ b/app/[locale]/(app)/explore/hives/page.tsx
@@ -3,6 +3,7 @@ import { Hexagon } from 'lucide-react';
 import { searchExplorableHivesAction } from '@/lib/actions/explore.actions';
 import { ExploreSearchBar } from '@/components/explore/explore-search-bar';
 import { ExploreSidebar } from '@/components/explore/explore-sidebar';
+import { ExploreLoadMoreButton } from '@/components/explore/explore-load-more';
 import HiveCard from '@/components/hive/hive-card';
 import { GENRES } from '@/lib/config/constants';
 
@@ -11,13 +12,13 @@ export const metadata: Metadata = { title: 'Explore Hives' };
 export default async function ExploreHivesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; genre?: string; tag?: string }>;
+  searchParams: Promise<{ q?: string; genre?: string; tag?: string; cursor?: string }>;
 }) {
-  const { q = '', genre = '', tag = '' } = await searchParams;
+  const { q = '', genre = '', tag = '', cursor } = await searchParams;
   const genres = genre ? genre.split(',').filter(Boolean) : [];
   const tags = tag ? tag.split(',').filter(Boolean) : [];
 
-  const hives = await searchExplorableHivesAction(q, genres, tags);
+  const { hives, nextCursor } = await searchExplorableHivesAction(q, genres, tags, cursor);
 
   const filterGroups = [{ param: 'genre', label: 'Genre', options: GENRES }];
 
@@ -31,7 +32,6 @@ export default async function ExploreHivesPage({
           <Hexagon className="w-6 h-6 text-[#FFC300]" />
           Writing Hives
         </h1>
-
       </div>
 
       <ExploreSearchBar placeholder="Search hives by name, genre, or tags..." />
@@ -51,11 +51,14 @@ export default async function ExploreHivesPage({
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-              {hives.map((hive) => (
-                <HiveCard key={hive.id} hive={hive} />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                {hives.map((hive) => (
+                  <HiveCard key={hive.id} hive={hive} />
+                ))}
+              </div>
+              {nextCursor && <ExploreLoadMoreButton nextCursor={nextCursor} />}
+            </>
           )}
         </div>
       </div>

--- a/app/[locale]/(app)/explore/prompts/page.tsx
+++ b/app/[locale]/(app)/explore/prompts/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Lightbulb } from 'lucide-react';
 import { searchExplorablePromptsAction } from '@/lib/actions/explore.actions';
 import { ExploreSearchBar } from '@/components/explore/explore-search-bar';
+import { ExploreLoadMoreButton } from '@/components/explore/explore-load-more';
 import { PromptCard } from '@/components/prompts/prompt-card';
 
 export const metadata: Metadata = { title: 'Explore Prompts' };
@@ -9,11 +10,11 @@ export const metadata: Metadata = { title: 'Explore Prompts' };
 export default async function ExplorePromptsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: Promise<{ q?: string; cursor?: string }>;
 }) {
-  const { q = '' } = await searchParams;
+  const { q = '', cursor } = await searchParams;
 
-  const prompts = await searchExplorablePromptsAction(q);
+  const { prompts, nextCursor } = await searchExplorablePromptsAction(q, cursor);
 
   return (
     <div className="space-y-6">
@@ -25,7 +26,6 @@ export default async function ExplorePromptsPage({
           <Lightbulb className="w-6 h-6 text-purple-400" />
           Writing Prompts
         </h1>
-
       </div>
 
       <ExploreSearchBar placeholder="Search writing prompts..." />
@@ -39,11 +39,14 @@ export default async function ExplorePromptsPage({
           <p className="text-white/80 max-w-sm">Try different keywords.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-          {prompts.map((prompt) => (
-            <PromptCard key={prompt.id} prompt={prompt} />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+            {prompts.map((prompt) => (
+              <PromptCard key={prompt.id} prompt={prompt} />
+            ))}
+          </div>
+          {nextCursor && <ExploreLoadMoreButton nextCursor={nextCursor} />}
+        </>
       )}
     </div>
   );

--- a/app/[locale]/(app)/explore/reading-lists/page.tsx
+++ b/app/[locale]/(app)/explore/reading-lists/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { List } from 'lucide-react';
 import { searchExplorableReadingListsAction } from '@/lib/actions/explore.actions';
 import { ExploreSearchBar } from '@/components/explore/explore-search-bar';
+import { ExploreLoadMoreButton } from '@/components/explore/explore-load-more';
 import ReadingListCard from '@/components/reading-lists/reading-list-card';
 
 export const metadata: Metadata = { title: 'Explore Reading Lists' };
@@ -9,11 +10,11 @@ export const metadata: Metadata = { title: 'Explore Reading Lists' };
 export default async function ExploreReadingListsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: Promise<{ q?: string; cursor?: string }>;
 }) {
-  const { q = '' } = await searchParams;
+  const { q = '', cursor } = await searchParams;
 
-  const lists = await searchExplorableReadingListsAction(q);
+  const { readingLists, nextCursor } = await searchExplorableReadingListsAction(q, cursor);
 
   return (
     <div className="space-y-6">
@@ -25,12 +26,11 @@ export default async function ExploreReadingListsPage({
           <List className="w-6 h-6 text-emerald-400" />
           Reading Lists
         </h1>
-
       </div>
 
       <ExploreSearchBar placeholder="Search reading lists..." />
 
-      {lists.length === 0 ? (
+      {readingLists.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <div className="w-16 h-16 rounded-xl border-2 border-dashed border-[#FFC300]/20 bg-[#FFC300]/5 flex items-center justify-center mb-8">
             <List className="w-8 h-8 text-[#FFC300]/20" />
@@ -39,11 +39,14 @@ export default async function ExploreReadingListsPage({
           <p className="text-white/80 max-w-sm">Try different keywords.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-          {lists.map((list) => (
-            <ReadingListCard key={list.id} list={list} />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+            {readingLists.map((list) => (
+              <ReadingListCard key={list.id} list={list} />
+            ))}
+          </div>
+          {nextCursor && <ExploreLoadMoreButton nextCursor={nextCursor} />}
+        </>
       )}
     </div>
   );

--- a/components/explore/explore-load-more.tsx
+++ b/components/explore/explore-load-more.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+
+export function ExploreLoadMoreButton({ nextCursor }: { nextCursor: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  function handleLoadMore() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('cursor', nextCursor);
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
+  }
+
+  return (
+    <div className="flex justify-center mt-8">
+      <button
+        onClick={handleLoadMore}
+        disabled={isPending}
+        className="flex items-center gap-2 rounded-full border border-[#2a2a2a] bg-[#1e1e1e] px-6 py-2.5 text-sm font-medium text-white/70 hover:text-white hover:border-[#444] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isPending ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Loading…
+          </>
+        ) : (
+          'Load more'
+        )}
+      </button>
+    </div>
+  );
+}

--- a/lib/actions/explore.actions.ts
+++ b/lib/actions/explore.actions.ts
@@ -4,7 +4,7 @@ import { requireAuth, getOptionalUserId } from '@/lib/require-auth';
 import { searchLimiter } from '@/lib/rate-limit';
 
 import { unstable_cache } from 'next/cache';
-import { and, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
+import { and, desc, eq, ilike, inArray, lt, or, sql } from 'drizzle-orm';
 import { db } from '@/db';
 import {
   books,
@@ -64,11 +64,14 @@ function mapBook(b: typeof books.$inferSelect): Book {
 
 
 
+const LIMIT = 30;
+
 export async function searchExplorableBooksAction(
   query: string,
   genres: string[] = [],
   categories: string[] = [],
-): Promise<Book[]> {
+  cursor?: string,
+): Promise<{ books: Book[]; nextCursor: string | null }> {
   const userId = await getOptionalUserId();
   const { success } = await searchLimiter.limit(userId ?? 'anon');
   if (!success) throw new Error('Too many requests. Please slow down.');
@@ -81,11 +84,18 @@ export async function searchExplorableBooksAction(
       q ? or(ilike(books.title, `%${q}%`), ilike(books.author, `%${q}%`)) : undefined,
       genres.length > 0 ? inArray(books.genre, genres) : undefined,
       categories.length > 0 ? inArray(books.category, categories) : undefined,
+      cursor ? lt(books.createdAt, new Date(cursor)) : undefined,
     ),
     orderBy: [desc(books.createdAt)],
-    limit: 30,
+    limit: LIMIT + 1,
   });
-  return rows.map(mapBook);
+
+  const hasMore = rows.length > LIMIT;
+  const items = hasMore ? rows.slice(0, LIMIT) : rows;
+  return {
+    books: items.map(mapBook),
+    nextCursor: hasMore ? items[LIMIT - 1].createdAt.toISOString() : null,
+  };
 }
 
 
@@ -93,12 +103,14 @@ export async function searchExplorableBooksAction(
 export async function searchExplorableClubsAction(
   query: string,
   tags: string[] = [],
-): Promise<ClubWithMembership[]> {
+  cursor?: string,
+): Promise<{ clubs: ClubWithMembership[]; nextCursor: string | null }> {
   const userId = await requireAuth();
   const { success } = await searchLimiter.limit(userId ?? 'anon');
   if (!success) throw new Error('Too many requests. Please slow down.');
 
   const q = query.trim();
+  const cursorFilter = cursor ? lt(bookClubs.createdAt, new Date(cursor)) : undefined;
 
   const tagFilter =
     tags.length > 0
@@ -114,14 +126,19 @@ export async function searchExplorableClubsAction(
     : undefined;
 
   const publicPromise = db.query.bookClubs.findMany({
-    where: and(eq(bookClubs.explorable, true), eq(bookClubs.privacy, 'PUBLIC'), queryFilter, tagFilter),
+    where: and(eq(bookClubs.explorable, true), eq(bookClubs.privacy, 'PUBLIC'), queryFilter, tagFilter, cursorFilter),
     orderBy: [desc(bookClubs.memberCount), desc(bookClubs.createdAt)],
-    limit: 30,
+    limit: LIMIT + 1,
   });
 
   if (!userId) {
-    const clubs = await publicPromise;
-    return clubs.map((c) => ({ ...c, tags: c.tags as string[], myRole: null, isMember: false }));
+    const rows = await publicPromise;
+    const hasMore = rows.length > LIMIT;
+    const items = hasMore ? rows.slice(0, LIMIT) : rows;
+    return {
+      clubs: items.map((c) => ({ ...c, tags: c.tags as string[], myRole: null, isMember: false })),
+      nextCursor: hasMore ? items[LIMIT - 1].createdAt.toISOString() : null,
+    };
   }
 
   const friendIds = await getFriendIds(userId);
@@ -135,33 +152,42 @@ export async function searchExplorableClubsAction(
             inArray(bookClubs.ownerId, friendIds),
             queryFilter,
             tagFilter,
+            cursorFilter,
           ),
           orderBy: [desc(bookClubs.memberCount), desc(bookClubs.createdAt)],
-          limit: 30,
+          limit: LIMIT + 1,
         })
       : Promise.resolve([]),
   ]);
 
-  const allClubs = [...publicClubs, ...friendClubs];
-  if (allClubs.length === 0) return [];
+  // Deduplicate, sort by createdAt desc, slice to LIMIT+1
+  const seen = new Set<string>();
+  const combined = [...publicClubs, ...friendClubs]
+    .filter((c) => { if (seen.has(c.id)) return false; seen.add(c.id); return true; })
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+  const hasMore = combined.length > LIMIT;
+  const allClubs = hasMore ? combined.slice(0, LIMIT) : combined;
+
+  if (allClubs.length === 0) return { clubs: [], nextCursor: null };
 
   const myMemberships = await db.query.clubMembers.findMany({
     where: and(
       eq(clubMembers.userId, userId),
-      inArray(
-        clubMembers.clubId,
-        allClubs.map((c) => c.id),
-      ),
+      inArray(clubMembers.clubId, allClubs.map((c) => c.id)),
     ),
   });
   const memberMap = new Map(myMemberships.map((m) => [m.clubId, m.role as ClubRole]));
 
-  return allClubs.map((c) => ({
-    ...c,
-    tags: c.tags as string[],
-    myRole: memberMap.get(c.id) ?? null,
-    isMember: memberMap.has(c.id),
-  }));
+  return {
+    clubs: allClubs.map((c) => ({
+      ...c,
+      tags: c.tags as string[],
+      myRole: memberMap.get(c.id) ?? null,
+      isMember: memberMap.has(c.id),
+    })),
+    nextCursor: hasMore ? allClubs[LIMIT - 1].createdAt.toISOString() : null,
+  };
 }
 
 
@@ -169,12 +195,14 @@ export async function searchExplorableHivesAction(
   query: string,
   genres: string[] = [],
   tags: string[] = [],
-): Promise<HiveWithMembership[]> {
+  cursor?: string,
+): Promise<{ hives: HiveWithMembership[]; nextCursor: string | null }> {
   const userId = await requireAuth();
   const { success } = await searchLimiter.limit(userId ?? 'anon');
   if (!success) throw new Error('Too many requests. Please slow down.');
 
   const q = query.trim();
+  const cursorFilter = cursor ? lt(hives.createdAt, new Date(cursor)) : undefined;
 
   const tagFilter =
     tags.length > 0
@@ -188,14 +216,19 @@ export async function searchExplorableHivesAction(
   const genreFilter = genres.length > 0 ? inArray(hives.genre, genres) : undefined;
 
   const publicPromise = db.query.hives.findMany({
-    where: and(eq(hives.explorable, true), eq(hives.privacy, 'PUBLIC'), queryFilter, genreFilter, tagFilter),
+    where: and(eq(hives.explorable, true), eq(hives.privacy, 'PUBLIC'), queryFilter, genreFilter, tagFilter, cursorFilter),
     orderBy: [desc(hives.memberCount), desc(hives.createdAt)],
-    limit: 30,
+    limit: LIMIT + 1,
   });
 
   if (!userId) {
-    const allHives = await publicPromise;
-    return allHives.map((h) => ({ ...h, tags: h.tags as string[], myRole: null, isMember: false }));
+    const rows = await publicPromise;
+    const hasMore = rows.length > LIMIT;
+    const items = hasMore ? rows.slice(0, LIMIT) : rows;
+    return {
+      hives: items.map((h) => ({ ...h, tags: h.tags as string[], myRole: null, isMember: false })),
+      nextCursor: hasMore ? items[LIMIT - 1].createdAt.toISOString() : null,
+    };
   }
 
   const friendIds = await getFriendIds(userId);
@@ -210,38 +243,50 @@ export async function searchExplorableHivesAction(
             queryFilter,
             genreFilter,
             tagFilter,
+            cursorFilter,
           ),
           orderBy: [desc(hives.memberCount), desc(hives.createdAt)],
-          limit: 30,
+          limit: LIMIT + 1,
         })
       : Promise.resolve([]),
   ]);
 
-  const allHivesList = [...publicHiveList, ...friendHives];
-  if (allHivesList.length === 0) return [];
+  // Deduplicate, sort by createdAt desc, slice to LIMIT+1
+  const seen = new Set<string>();
+  const combined = [...publicHiveList, ...friendHives]
+    .filter((h) => { if (seen.has(h.id)) return false; seen.add(h.id); return true; })
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+  const hasMore = combined.length > LIMIT;
+  const allHivesList = hasMore ? combined.slice(0, LIMIT) : combined;
+
+  if (allHivesList.length === 0) return { hives: [], nextCursor: null };
 
   const myMemberships = await db.query.hiveMembers.findMany({
     where: and(
       eq(hiveMembers.userId, userId),
-      inArray(
-        hiveMembers.hiveId,
-        allHivesList.map((h) => h.id),
-      ),
+      inArray(hiveMembers.hiveId, allHivesList.map((h) => h.id)),
     ),
   });
   const memberMap = new Map(myMemberships.map((m) => [m.hiveId, m.role as HiveRole]));
 
-  return allHivesList.map((h) => ({
-    ...h,
-    tags: h.tags as string[],
-    myRole: memberMap.get(h.id) ?? null,
-    isMember: memberMap.has(h.id),
-  }));
+  return {
+    hives: allHivesList.map((h) => ({
+      ...h,
+      tags: h.tags as string[],
+      myRole: memberMap.get(h.id) ?? null,
+      isMember: memberMap.has(h.id),
+    })),
+    nextCursor: hasMore ? allHivesList[LIMIT - 1].createdAt.toISOString() : null,
+  };
 }
 
 
 
-export async function searchExplorablePromptsAction(query: string): Promise<PromptCard[]> {
+export async function searchExplorablePromptsAction(
+  query: string,
+  cursor?: string,
+): Promise<{ prompts: PromptCard[]; nextCursor: string | null }> {
   const userId = await requireAuth();
   const { success } = await searchLimiter.limit(userId ?? 'anon');
   if (!success) throw new Error('Too many requests. Please slow down.');
@@ -253,45 +298,52 @@ export async function searchExplorablePromptsAction(query: string): Promise<Prom
       eq(prompts.explorable, true),
       eq(prompts.privacy, 'PUBLIC'),
       q ? or(ilike(prompts.title, `%${q}%`), ilike(prompts.description, `%${q}%`)) : undefined,
+      cursor ? lt(prompts.createdAt, new Date(cursor)) : undefined,
     ),
     with: { creator: { columns: USER_COLUMNS } },
     orderBy: [desc(prompts.createdAt)],
-    limit: 30,
+    limit: LIMIT + 1,
   });
 
+  const hasMore = rows.length > LIMIT;
+  const items = hasMore ? rows.slice(0, LIMIT) : rows;
+
   let myEntryMap = new Map<string, string>();
-  if (userId && rows.length > 0) {
+  if (userId && items.length > 0) {
     const myEntries = await db.query.promptEntries.findMany({
       where: and(
         eq(promptEntries.userId, userId),
-        inArray(
-          promptEntries.promptId,
-          rows.map((r) => r.id),
-        ),
+        inArray(promptEntries.promptId, items.map((r) => r.id)),
       ),
       columns: { id: true, promptId: true },
     });
     myEntryMap = new Map(myEntries.map((e) => [e.promptId, e.id]));
   }
 
-  return rows.map((p) => ({
-    id: p.id,
-    title: p.title,
-    description: p.description,
-    endDate: p.endDate,
-    privacy: p.privacy as 'PUBLIC' | 'FRIENDS' | 'PRIVATE',
-    explorable: p.explorable,
-    status: (p.endDate < new Date() ? 'ENDED' : p.status) as 'ACTIVE' | 'ENDED',
-    entryCount: p.entryCount,
-    createdAt: p.createdAt,
-    creator: p.creator as PromptUser,
-    myInviteStatus: null,
-    myEntryId: myEntryMap.get(p.id) ?? null,
-  }));
+  return {
+    prompts: items.map((p) => ({
+      id: p.id,
+      title: p.title,
+      description: p.description,
+      endDate: p.endDate,
+      privacy: p.privacy as 'PUBLIC' | 'FRIENDS' | 'PRIVATE',
+      explorable: p.explorable,
+      status: (p.endDate < new Date() ? 'ENDED' : p.status) as 'ACTIVE' | 'ENDED',
+      entryCount: p.entryCount,
+      createdAt: p.createdAt,
+      creator: p.creator as PromptUser,
+      myInviteStatus: null,
+      myEntryId: myEntryMap.get(p.id) ?? null,
+    })),
+    nextCursor: hasMore ? items[LIMIT - 1].createdAt.toISOString() : null,
+  };
 }
 
 
-export async function searchExplorableReadingListsAction(query: string): Promise<ReadingList[]> {
+export async function searchExplorableReadingListsAction(
+  query: string,
+  cursor?: string,
+): Promise<{ readingLists: ReadingList[]; nextCursor: string | null }> {
   const userId = await getOptionalUserId();
   const { success } = await searchLimiter.limit(userId ?? 'anon');
   if (!success) throw new Error('Too many requests. Please slow down.');
@@ -302,11 +354,18 @@ export async function searchExplorableReadingListsAction(query: string): Promise
       eq(readingLists.explorable, true),
       eq(readingLists.privacy, 'PUBLIC'),
       q ? ilike(readingLists.title, `%${q}%`) : undefined,
+      cursor ? lt(readingLists.updatedAt, new Date(cursor)) : undefined,
     ),
     orderBy: [desc(readingLists.updatedAt)],
-    limit: 30,
+    limit: LIMIT + 1,
   });
-  return rows.map((r) => ({ ...r, privacy: r.privacy as ReadingList['privacy'] }));
+
+  const hasMore = rows.length > LIMIT;
+  const items = hasMore ? rows.slice(0, LIMIT) : rows;
+  return {
+    readingLists: items.map((r) => ({ ...r, privacy: r.privacy as ReadingList['privacy'] })),
+    nextCursor: hasMore ? items[LIMIT - 1].updatedAt.toISOString() : null,
+  };
 }
 
 


### PR DESCRIPTION
Adds cursor-based pagination to all five explore search actions and their corresponding pages.

Changes:
- lib/actions/explore.actions.ts — all search actions now accept an optional cursor param and return { data, nextCursor }
- explore/books, clubs, hives, prompts, reading-lists pages — read cursor from searchParams, pass to action
- New ExploreLoadMoreButton component — client component that appends cursor to URL on click
Uses limit+1 trick to detect if more results exist. nextCursor is the ISO timestamp of the last item returned. Browser back button works correctly since cursor is URL-based.